### PR TITLE
Add MakeProtective method for creating a Protective MBR.

### DIFF
--- a/mbr.go
+++ b/mbr.go
@@ -177,6 +177,7 @@ func (this *MBR) MakeProtective(sectorSize int, diskSize uint64) error {
 	pt.SetType(PART_GPT)
 	pt.SetLBAStart(1)
 	pt.SetLBALen(ptLenLBA)
+	pt.bytes[partitionBootableOffset] = partitionNonBootableValue
 
 	// zero the other partitions.
 	for pnum := 2; pnum <= 4; pnum++ {
@@ -184,6 +185,7 @@ func (this *MBR) MakeProtective(sectorSize int, diskSize uint64) error {
 		pt.SetType(PART_EMPTY)
 		pt.SetLBAStart(0)
 		pt.SetLBALen(0)
+		pt.bytes[partitionBootableOffset] = partitionNonBootableValue
 	}
 
 	return nil


### PR DESCRIPTION
In almost all cases, when creating new partition tables, a user should
create an GPT Table.  GPT requires a Protective MBR.
Add the MakeProtective method to the MBR interface so that someone
can easiliy create a valid Protective MBR.

The size change on the check for ErrorPartitionLastSectorHigh was
required in order to make a partition of the largest uint32 size
that starts at offset 1.  This is how gdisk makes its partition tables
for disks larger than 2TiB.