### PR TITLE
Add MBRPartition.SetBootable() to set the bootable flag.

### DIFF
--- a/mbr.go
+++ b/mbr.go
@@ -209,6 +209,17 @@ func (this *MBRPartition) SetLBALen(sectorCount uint32) {
 }
 
 /*
+Set the Bootable flag on this partition.
+*/
+func (this *MBRPartition) SetBootable(bootable bool) {
+	if bootable {
+		this.bytes[partitionBootableOffset] = partitionBootableValue
+	} else {
+		this.bytes[partitionBootableOffset] = partitionNonBootableValue
+	}
+}
+
+/*
 Return true if this partition's bootable flag is set.
 */
 func (this *MBRPartition) IsBootable() bool {


### PR DESCRIPTION
There is currently no write access to the Bootable flag of a
MBRPartition.  This just adds a simple SetBootablel method on the
MBRPartition struct to do that.